### PR TITLE
Model training speed up and support AE loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ MindPose is an open-source toolbox for pose estimation based on [MindSpore](http
 - numpy >= 1.20.0
 - pyyaml >= 5.3
 - opencv_python_headless < 4.3
-- xtcocotools >= 1.13
+- pycocotools >= 2.0.6
 - tqdm
 - openmpi 4.0.3 (for distributed mode) 
 

--- a/configs/hrnet/hrnet_w32_ascend.yaml
+++ b/configs/hrnet/hrnet_w32_ascend.yaml
@@ -2,7 +2,7 @@
 mode: 0
 distribute: True
 enable_graph_kernel: False
-num_parallel_workers: 8
+num_parallel_workers: 4
 val_while_train: True
 val_interval: 10
 save_best: True

--- a/configs/hrnet/hrnet_w48_ascend.yaml
+++ b/configs/hrnet/hrnet_w48_ascend.yaml
@@ -2,7 +2,7 @@
 mode: 0
 distribute: True
 enable_graph_kernel: False
-num_parallel_workers: 8
+num_parallel_workers: 4
 val_while_train: True
 val_interval: 10
 save_best: True

--- a/configs/simple_baseline/resnet101_ascend.yaml
+++ b/configs/simple_baseline/resnet101_ascend.yaml
@@ -2,7 +2,7 @@
 mode: 0
 distribute: True
 enable_graph_kernel: False
-num_parallel_workers: 8
+num_parallel_workers: 4
 val_while_train: True
 val_interval: 10
 save_best: True

--- a/configs/simple_baseline/resnet152_ascend.yaml
+++ b/configs/simple_baseline/resnet152_ascend.yaml
@@ -2,7 +2,7 @@
 mode: 0
 distribute: True
 enable_graph_kernel: False
-num_parallel_workers: 8
+num_parallel_workers: 4
 val_while_train: True
 val_interval: 10
 save_best: True

--- a/configs/simple_baseline/resnet50_ascend.yaml
+++ b/configs/simple_baseline/resnet50_ascend.yaml
@@ -2,7 +2,7 @@
 mode: 0
 distribute: True
 enable_graph_kernel: False
-num_parallel_workers: 8
+num_parallel_workers: 4
 val_while_train: True
 val_interval: 10
 save_best: True

--- a/configs/udp/hrnet_w32_udp_ascend.yaml
+++ b/configs/udp/hrnet_w32_udp_ascend.yaml
@@ -2,7 +2,7 @@
 mode: 0
 distribute: True
 enable_graph_kernel: False
-num_parallel_workers: 8
+num_parallel_workers: 4
 val_while_train: True
 val_interval: 10
 save_best: True

--- a/configs/udp/hrnet_w48_udp_ascend.yaml
+++ b/configs/udp/hrnet_w48_udp_ascend.yaml
@@ -2,7 +2,7 @@
 mode: 0
 distribute: True
 enable_graph_kernel: False
-num_parallel_workers: 8
+num_parallel_workers: 4
 val_while_train: True
 val_interval: 10
 save_best: True

--- a/configs/udp/resnet101_udp_ascend.yaml
+++ b/configs/udp/resnet101_udp_ascend.yaml
@@ -2,7 +2,7 @@
 mode: 0
 distribute: True
 enable_graph_kernel: False
-num_parallel_workers: 8
+num_parallel_workers: 4
 val_while_train: True
 val_interval: 10
 save_best: True

--- a/configs/udp/resnet152_udp_ascend.yaml
+++ b/configs/udp/resnet152_udp_ascend.yaml
@@ -2,7 +2,7 @@
 mode: 0
 distribute: True
 enable_graph_kernel: False
-num_parallel_workers: 8
+num_parallel_workers: 4
 val_while_train: True
 val_interval: 10
 save_best: True

--- a/configs/udp/resnet50_udp_ascend.yaml
+++ b/configs/udp/resnet50_udp_ascend.yaml
@@ -2,7 +2,7 @@
 mode: 0
 distribute: True
 enable_graph_kernel: False
-num_parallel_workers: 8
+num_parallel_workers: 4
 val_while_train: True
 val_interval: 10
 save_best: True

--- a/mindpose/data/column_names.py
+++ b/mindpose/data/column_names.py
@@ -41,12 +41,12 @@ _BOTTOMUP_TRAIN_COLUMN_NAMES = [
     "image",
     "boxes",
     "keypoints",
-    "mask",
     "target",
-    "keypoint_coordinate",
+    "mask",
+    "tag_mask",
 ]
 
-_BOTTOMUP_TRAIN_FINAL_COLUMN_NAMES = ["image", "mask", "target", "keypoint_coordinate"]
+_BOTTOMUP_TRAIN_FINAL_COLUMN_NAMES = ["image", "target", "mask", "tag_mask"]
 
 _BOTTOMUP_VAL_COLUMN_NAMES = ["image", "image_file"]
 

--- a/mindpose/data/data_factory.py
+++ b/mindpose/data/data_factory.py
@@ -141,7 +141,9 @@ def create_pipeline(
     dataset = dataset.project(final_column_names)
 
     # batch
-    dataset = dataset.batch(batch_size, drop_remainder=is_train)
+    dataset = dataset.batch(
+        batch_size, drop_remainder=is_train, num_parallel_workers=num_workers
+    )
     return dataset
 
 

--- a/mindpose/data/dataset/coco_topdown.py
+++ b/mindpose/data/dataset/coco_topdown.py
@@ -3,7 +3,7 @@ import os
 from typing import Any, Dict, List, Tuple
 
 import numpy as np
-from xtcocotools.coco import COCO
+from pycocotools.coco import COCO
 
 from ...register import register
 

--- a/mindpose/engine/evaluator/topdown_evaluator.py
+++ b/mindpose/engine/evaluator/topdown_evaluator.py
@@ -5,8 +5,8 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
-from xtcocotools.coco import COCO
-from xtcocotools.cocoeval import COCOeval
+from pycocotools.coco import COCO
+from pycocotools.cocoeval import COCOeval
 
 from mindpose.utils.nms import oks_nms, soft_oks_nms
 from ...register import register
@@ -208,9 +208,7 @@ class TopDownEvaluator(Evaluator):
     ) -> List[Tuple[str, List[np.ndarray]]]:
         """Keypoint evaluation using COCOAPI."""
         coco_det = self.coco.loadRes(res_file)
-        coco_eval = COCOeval(
-            self.coco, coco_det, "keypoints", np.asarray(self._evaluation_cfg["sigmas"])
-        )
+        coco_eval = COCOeval(self.coco, coco_det, "keypoints")
         coco_eval.params.useSegm = None
         coco_eval.evaluate()
         coco_eval.accumulate()

--- a/mindpose/models/loss/__init__.py
+++ b/mindpose/models/loss/__init__.py
@@ -1,5 +1,6 @@
+from .ae import AELoss
 from .loss import Loss
 from .mse import JointsMSELoss, JointsMSELossWithMask
+from .multi_loss import AEMultiLoss
 
-__all__ = ["Loss", "JointsMSELoss", "JointsMSELossWithMask"]
-
+__all__ = ["Loss", "JointsMSELoss", "JointsMSELossWithMask", "AELoss", "AEMultiLoss"]

--- a/mindpose/models/loss/ae.py
+++ b/mindpose/models/loss/ae.py
@@ -1,0 +1,63 @@
+from typing import Tuple, Union
+
+import mindspore as ms
+import mindspore.ops as ops
+from mindspore import Tensor
+
+from ...register import register
+from .loss import Loss
+
+
+@register("loss", extra_name="ae")
+class AELoss(Loss):
+    """Associative embedding loss. Or called `Grouping loss`. Implemented in vectorized way.
+
+    Args:
+        sigma: Sigma value in push loss. Default: 1.0
+        reduce: Whether reduce the loss into the single value. Default: False
+
+    Inputs:
+        | pred: Predicted tags. In shape [N, K, H, W]. Where K stands for the
+            number of joints.
+        | target: Ground truth of tag mask. In shape [N, M, K, H, W]. Where M stands
+            for number of instances.
+
+    Outputs:
+        | loss: Loss value if reduce is True; Otherwise return the tuple of pull and
+            push loss
+    """
+
+    def __init__(self, sigma: float = 1.0, reduce: bool = False) -> None:
+        super().__init__()
+        self.sigma = sigma
+        self.reduce = reduce
+
+    def construct(
+        self, pred: Tensor, target: Tensor
+    ) -> Union[Tensor, Tuple[Tensor, Tensor]]:
+        N, M, K, _, _ = target.shape
+
+        target = ops.cast(target, ms.bool_)
+
+        pred = pred[:, None, ...]
+        pred = ops.masked_fill(pred, ~target, 0.0)
+
+        # calculate the reference embedding for each instance
+        h_n = pred.sum(axis=(2, 3, 4)) / K
+
+        # calculate the pull loss
+        diff = (h_n[..., None, None, None] - pred) * target
+        pull_loss = (diff**2).sum(axis=(1, 2, 3, 4)) / (M * K)
+
+        # calculate the push loss
+        A = ops.broadcast_to(h_n[..., None], (N, M, M))
+        B = ops.transpose(A, (0, 2, 1))
+        diff = A - B
+        push_loss = (
+            ops.exp(-1 / 2 / self.sigma**2 * diff**2).sum(axis=(1, 2)) / M**2
+        )
+
+        if self.reduce:
+            return push_loss.mean() + pull_loss.mean()
+
+        return pull_loss, push_loss

--- a/mindpose/models/loss/mse.py
+++ b/mindpose/models/loss/mse.py
@@ -47,8 +47,8 @@ class JointsMSELoss(Loss):
 
 @register("loss", extra_name="joint_mse_with_mask")
 class JointsMSELossWithMask(Loss):
-    """Joint Mean square error loss with mask
-    It is the MSE loss of heatmaps with mask on different position.
+    """Joint Mean square error loss with mask.
+    Mask-out position will not contribute to the loss.
 
     Inputs:
         | pred: Predictions, in shape [N, C, H, W]

--- a/mindpose/models/loss/multi_loss.py
+++ b/mindpose/models/loss/multi_loss.py
@@ -1,0 +1,100 @@
+from typing import List, Tuple
+
+from mindspore import Tensor
+
+from ...register import register
+from .ae import AELoss
+from .loss import Loss
+from .mse import JointsMSELossWithMask
+
+
+@register("loss", extra_name="ae_multi_loss")
+class AEMultiLoss(Loss):
+    """Combined loss of MSE and AE for multi levels of resolutions
+
+    Args:
+        num_joints: Number of joints. Default: 17
+        num_stages: Number of resolution levels. Default: 2
+        stage_sizes: The sizes in each stage. Default: [(128, 128), (256, 256)]
+        mse_loss_factor: Weighting for MSE loss at each level. Default: [1.0, 1.0]
+        ae_loss_factor: Weighting for Associative embedding loss at each level.
+            Default: [0.001, 0.001]
+        with_mse_loss: Whether each level involves calculating MSE loss.
+            Default: [True, False]
+        with_ae_loss: Whether each level involves calculating AE loss.
+            Default: [True, False]
+        sigma: Sigma vvalue in AE loss. Default: 1.0
+
+    Inputs:
+        | pred: List of prediction result at each resolution level. In shape [N, aK,
+            H, W]. Where K stands for the number of joints. a=2 if the correspoinding
+            with_ae_loss is True
+        | target: Ground truth of heatmap. In shape [N, S, K, H, W]. Where S stands for
+            the number of resolution levels.
+        | mask: Ground truth of the heatmap mask. In shape [N, S, H, W].
+        | tag_mask: Ground truth of tag position. In shape [N, S, M, K, H, W]. Where M
+            stands for number of instances.
+
+    Outputs:
+        | loss: Single Loss value
+    """
+
+    def __init__(
+        self,
+        num_joints: int = 17,
+        num_stages: int = 2,
+        stage_sizes: List[Tuple[int, int]] = [(128, 128), (256, 256)],
+        mse_loss_factor: List[float] = [1.0, 1.0],
+        ae_loss_factor: List[float] = [0.001, 0.001],
+        with_mse_loss: List[bool] = [True, True],
+        with_ae_loss: List[bool] = [True, False],
+        sigma: float = 1.0,
+    ) -> None:
+        super().__init__()
+        self.mse_criterion = JointsMSELossWithMask()
+        self.ae_criterion = AELoss(sigma=sigma, reduce=True)
+
+        self.num_joints = num_joints
+        self.num_stages = num_stages
+        self.stage_sizes = stage_sizes
+        self.mse_loss_factor = mse_loss_factor
+        self.ae_loss_factor = ae_loss_factor
+        self.with_mse_loss = with_mse_loss
+        self.with_ae_loss = with_ae_loss
+
+        if any(self.with_ae_loss):
+            if not with_ae_loss[0]:
+                raise ValueError(
+                    "0th element of `with_ae_loss` must be true "
+                    "in case when ae_loss is used."
+                )
+
+    def construct(
+        self,
+        pred: List[Tensor],
+        target: Tensor,
+        mask: Tensor,
+        tag_mask: Tensor,
+    ) -> Tensor:
+        loss = 0.0
+
+        for i in range(self.num_stages):
+            W, H = self.stage_sizes[i]
+            if self.with_mse_loss[i]:
+                loss += (
+                    self.mse_criterion(
+                        pred[i][:, : self.num_joints, ...],
+                        target[:, i, :, :H, :W],
+                        mask[:, i, :H, :W],
+                    )
+                    * self.mse_loss_factor[i]
+                )
+
+            if self.with_ae_loss[i]:
+                loss += (
+                    self.ae_criterion(
+                        pred[i][:, self.num_joints :, ...], tag_mask[:, i, ...]
+                    )
+                    * self.ae_loss_factor[i]
+                )
+        return loss

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.20.0
 pyyaml>=5.3
-xtcocotools>=1.13
+pycocotools>=2.0.6
 opencv_python_headless<4.3
 tqdm

--- a/tests/models/loss/test_ae.py
+++ b/tests/models/loss/test_ae.py
@@ -1,0 +1,23 @@
+import mindspore as ms
+import numpy as np
+
+from mindpose.models.loss.ae import AELoss
+from mindspore import Tensor
+
+
+def test_ae_with_reduce_is_true():
+    ms.set_context(mode=ms.GRAPH_MODE)
+
+    criterion = AELoss(reduce=True)
+
+    # pred: [N, K, H, W]
+    pred = Tensor(
+        np.arange(0, 2 * 3 * 4 * 4).reshape(2, 3, 4, 4) * 0.01, dtype=ms.float32
+    )
+
+    # target: [N, M, K, H, W]
+    target = np.random.randint(2, size=(2, 5, 3, 4, 4), dtype=np.uint8)
+    target = Tensor(target)
+
+    loss = criterion(pred, target)
+    assert loss.size == 1

--- a/tests/models/loss/test_mse.py
+++ b/tests/models/loss/test_mse.py
@@ -32,6 +32,6 @@ def test_joint_mse_with_mask():
     criterion = JointsMSELossWithMask()
     pred = Tensor(np.random.random((4, 12, 32, 32)), dtype=ms.float32)
     target = Tensor(np.random.random((4, 12, 32, 32)), dtype=ms.float32)
-    mask = Tensor(np.random.choice(2, size=(4, 32, 32)), dtype=ms.float32)
+    mask = Tensor(np.random.randint(2, size=(4, 32, 32)), dtype=ms.uint8)
     loss = criterion(pred, target, mask)
     assert loss.size == 1

--- a/tests/models/loss/test_multi_loss.py
+++ b/tests/models/loss/test_multi_loss.py
@@ -1,0 +1,27 @@
+import mindspore as ms
+import numpy as np
+
+from mindpose.models.loss.multi_loss import AEMultiLoss
+from mindspore import Tensor
+
+
+def test_ae_multi_loss():
+    ms.set_context(mode=ms.GRAPH_MODE)
+
+    num_joints = 3
+    criterion = AEMultiLoss(
+        num_joints=num_joints,
+        with_ae_loss=[True, False],
+        stage_sizes=[(16, 16), (32, 32)],
+    )
+    pred = [
+        Tensor(np.random.random((4, 2 * num_joints, 16, 16)), dtype=ms.float32),
+        Tensor(np.random.random((4, num_joints, 32, 32)), dtype=ms.float32),
+    ]
+    target = Tensor(np.random.random((4, 2, num_joints, 32, 32)), dtype=ms.float32)
+    mask = Tensor(np.random.randint(2, size=(4, 2, 32, 32)), dtype=ms.uint8)
+    tag_mask = Tensor(
+        np.random.randint(2, size=(4, 1, 5, num_joints, 16, 16)), dtype=ms.uint8
+    )
+    loss = criterion(pred, target, mask, tag_mask)
+    assert loss.size == 1


### PR DESCRIPTION
enhancemnts:
- Speed up the training process by setting the opencv thread limit and decrease the number of workers, preventing the thread racing in platforms with normal number of CPU cores
- Speed up the mask decoding process using the cached mask in numpy packbits
- Speed up the horizontal randomly flip augmentation by vectorizing the flipping pairs
- Add asscociative embedding loss and update the the corresponding data pipeline
- Add visualization support of the mask and tag mask in bottom-up approach

others
- Change the dependency requirement