### PR TITLE
Change loss base class and others

### DIFF
--- a/mindpose/data/dataset/bottomup.py
+++ b/mindpose/data/dataset/bottomup.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any, Dict, List, Optional
 
 import numpy as np
@@ -45,6 +46,7 @@ class BottomUpDataset:
         self.config = config if config else dict()
         self._dataset_cfg = self.load_dataset_cfg()
         self._dataset = self.load_dataset()
+        logging.info(f"Number of records in dataset: {len(self._dataset)}")
 
     def load_dataset_cfg(self) -> Dict[str, Any]:
         """Loading the dataset config, where the returned config must be a dictionary

--- a/mindpose/data/dataset/topdown.py
+++ b/mindpose/data/dataset/topdown.py
@@ -1,3 +1,4 @@
+import logging
 from copy import deepcopy
 from typing import Any, Dict, List, Optional
 
@@ -55,8 +56,6 @@ class TopDownDataset:
         self.use_gt_bbox_for_val = use_gt_bbox_for_val
         self.detection_file = detection_file
         self.config = config if config else dict()
-        self._dataset_cfg = self.load_dataset_cfg()
-        self._dataset = self.load_dataset()
 
         if self.annotation_file is None:
             if not self.is_train and not self.use_gt_bbox_for_val:
@@ -64,6 +63,10 @@ class TopDownDataset:
                     "For evaluation, `detection_file` must be provided "
                     "when `use_gt_bbox_for_val` is `False`"
                 )
+
+        self._dataset_cfg = self.load_dataset_cfg()
+        self._dataset = self.load_dataset()
+        logging.info(f"Number of records in dataset: {len(self._dataset)}")
 
     def load_dataset_cfg(self) -> Dict[str, Any]:
         """Loading the dataset config, where the returned config must be a dictionary

--- a/mindpose/models/loss/loss.py
+++ b/mindpose/models/loss/loss.py
@@ -1,7 +1,7 @@
 import mindspore.nn as nn
 
 
-class Loss(nn.Cell):
+class Loss(nn.LossBase):
     """Abstract class for all losses."""
 
     ...

--- a/tests/models/loss/test_ae.py
+++ b/tests/models/loss/test_ae.py
@@ -8,7 +8,7 @@ from mindspore import Tensor
 def test_ae():
     ms.set_context(mode=ms.GRAPH_MODE)
 
-    criterion = AELoss(reduce=True)
+    criterion = AELoss()
 
     # pred: [N, K, H, W]
     pred = Tensor(
@@ -28,7 +28,7 @@ def test_ae():
 def test_ae_with_tag_per_joint_is_false():
     ms.set_context(mode=ms.GRAPH_MODE)
 
-    criterion = AELoss(reduce=True, tag_per_joint=False)
+    criterion = AELoss(tag_per_joint=False)
 
     # pred: [N, H, W]
     pred = Tensor(np.arange(0, 2 * 1 * 4 * 4).reshape(2, 4, 4) * 0.01, dtype=ms.float32)


### PR DESCRIPTION
Enhancements:
- Change loss base class from nn.Cell to nn.LossBase, and use the its default reduce method for `ae` loss and `mse` loss.
- EvalCallback writes the loss value separately in summary record if it involves multi-loss calculation.
- Print the number of records when creating the dataset.

Bug fixes:
- Fix the bug that the loss_meter is not reset to zero after each epoch, which cause the printed loss value incorrect.